### PR TITLE
Remove trailing comma

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,5 +33,5 @@
   },
   "nbbpm": {
     "compatibility": "^1.0.0"
-  },
+  }
 }


### PR DESCRIPTION
The installation of the update branch fails due to this trailing comma. I removed it and installtion was successfull.