### PR TITLE
 Bugfix: crash in latest nodebb version (1.10.x)

### DIFF
--- a/library.js
+++ b/library.js
@@ -30,12 +30,14 @@
 
         query.on("timeout", function(err) {
             var reason = {reason: "Connection timed out!"};
-            callback(null, {html: ts3Error(reason, err)});
+            widget.html = ts3Error(reason, err);
+            callback(null, widget);
         });
 
         query.on("error", function(err) {
             var reason = {reason: "Connection error!"};
-            callback(null, {html: ts3Error(reason, err)});
+            widget.html = ts3Error(reason, err);
+            callback(null, widget);
         });
 
         query.on("connect", function(res) {
@@ -47,7 +49,8 @@
                     // login fail or ban
                     var reason = {reason: "Query login failed!"};
                     query.send("quit");
-                    callback(null, {html: ts3Error(reason, err)});
+                    widget.html = ts3Error(reason, err);
+                    callback(null, widget);
                     return;
                 }
 
@@ -58,7 +61,8 @@
                         // no such server
                         var reason = {reason: "Invalid SID!"};
                         query.send("quit");
-                        callback(null, {html: ts3Error(reason, err)});
+                        widget.html = ts3Error(reason, err);
+                        callback(null, widget);
                         return;
                     }
 
@@ -144,8 +148,8 @@
 
                             return html;
                         }
-
-                        callback(null, {html: templates.parse(pre, rep)});
+                        widget.html = templates.parse(pre, rep);
+                        callback(null, widget);
 
                     }
 

--- a/library.js
+++ b/library.js
@@ -23,7 +23,7 @@
         
         function ts3Error(reason, err) {
             console.error(err);
-            var errhtml = "" + fs.readFileSync("./public/templates/ts3-err.tpl");
+            var errhtml = "" + fs.readFileSync(path.resolve(__dirname, "./public/templates/ts3-err.tpl"));
             errhtml = errhtml.replace(new RegExp("{{errormessage}}", "g"), reason);
             return errhtml;
         }
@@ -74,7 +74,7 @@
                             }
                         }
 
-                        var pre = "" + fs.readFileSync("./public/templates/ts3.tpl");
+                        var pre = "" + fs.readFileSync(path.resolve(__dirname, "./public/templates/ts3.tpl"));
                         var rep = {
                             "ts3-online-clients": online_clients.length,
                             "ts3-server-name": serverInfo.name || "Teamspeak Server",


### PR DESCRIPTION
The widget was not compatible with current nodebb version (1.10.x). It crashes when it should get rendered. This bufix solves this.